### PR TITLE
Add mqttclient package

### DIFF
--- a/cmd/arduino-nano33-iot-wifi-mqttclient/main.go
+++ b/cmd/arduino-nano33-iot-wifi-mqttclient/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/waltervargas/arduino-nano33-iot/mqttclient"
+	"github.com/waltervargas/arduino-nano33-iot/wifi"
+)
+
+const (
+	mqttserver = "tcp://192.168.0.118:1883"
+	clientid   = "arduino-nano33-123"
+)
+
+func main() {
+	// ssid and pass defined as constants at secrets.go
+	w, err := wifi.Connect(ssid, pass)
+	if err != nil {
+		println("error connecting to wifi: " + err.Error())
+		os.Exit(1)
+	}
+
+	//check the connection status and wait for the connection to be success
+	for st, _ := w.GetConnectionStatus(); st != wifi.StatusConnected; {
+		println("Connection status: " + st.String())
+		time.Sleep(2 * time.Second)
+		st, _ = w.GetConnectionStatus()
+	}
+
+	println("connected to: " + ssid)
+	ipAddress, err := w.GetIPAddress()
+	if err != nil {
+		println(err.Error())
+	}
+
+	println("IP address: " + ipAddress)
+
+	mqttc, err := mqttclient.Connect(mqttserver, clientid)
+	if err != nil {
+		println("error connecting to mqtt: " + err.Error())
+	}
+
+	println("connected to MQTT server: " + mqttserver)
+
+	// testing sending messages to MQTT
+	println("publishing messages to server: " + mqttserver)
+
+	for {
+		rand.Seed(time.Now().Unix())
+		temp := rand.Intn(35)
+		err = mqttc.PublishMessage("iot/temperature", fmt.Sprintf(`{value: %v}`, temp))
+		if err != nil {
+			println("error sending message to mqtt")
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,8 @@ replace testing => /usr/local/lib/tinygo/src/testing
 
 require machine v0.0.0-00010101000000-000000000000
 
+require github.com/eclipse/paho.mqtt.golang v1.2.0 // indirect
+
 require (
 	device/arm v0.0.0-00010101000000-000000000000 // indirect
 	device/sam v0.0.0-00010101000000-000000000000 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/bgould/http v0.0.0-20190627042742-d268792bdee7/go.mod h1:BTqvVegvwifopl4KTEDth6Zezs9eR+lCWhvGKvkxJHE=
+github.com/eclipse/paho.mqtt.golang v1.2.0 h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t2y2qayIX0=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/frankban/quicktest v1.10.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/mqttclient/mqttclient.go
+++ b/mqttclient/mqttclient.go
@@ -10,18 +10,18 @@ type Client struct {
 	mqttClient mqtt.Client
 }
 
-func New(server, id string) Client {
+func New(server, id string) *Client {
 	opts := mqtt.NewClientOptions()
 	opts.AddBroker(server).SetClientID(id)
 
-	return Client{
+	return &Client{
 		server:     server,
 		id:         id,
 		mqttClient: mqtt.NewClient(opts),
 	}
 }
 
-func (c Client) connect() error {
+func (c *Client) connect() error {
 	if token := c.mqttClient.Connect(); token.Wait() && token.Error() != nil {
 		return token.Error()
 	}
@@ -29,17 +29,17 @@ func (c Client) connect() error {
 	return nil
 }
 
-func Connect(server, id string) (Client, error) {
+func Connect(server, id string) (*Client, error) {
 	c := New(server, id)
 	err := c.connect()
 	if err != nil {
-		return Client{}, err
+		return &Client{}, err
 	}
 
 	return c, nil
 }
 
-func (c Client) PublishMessage(path, message string) error {
+func (c *Client) PublishMessage(path, message string) error {
 	token := c.mqttClient.Publish(path, 1, false, message)
 	token.Wait()
 	if token.Error() != nil {

--- a/mqttclient/mqttclient.go
+++ b/mqttclient/mqttclient.go
@@ -1,0 +1,50 @@
+package mqttclient
+
+import (
+	"tinygo.org/x/drivers/net/mqtt"
+)
+
+type Client struct {
+	server     string
+	id         string
+	mqttClient mqtt.Client
+}
+
+func New(server, id string) Client {
+	opts := mqtt.NewClientOptions()
+	opts.AddBroker(server).SetClientID(id)
+
+	return Client{
+		server:     server,
+		id:         id,
+		mqttClient: mqtt.NewClient(opts),
+	}
+}
+
+func (c Client) connect() error {
+	if token := c.mqttClient.Connect(); token.Wait() && token.Error() != nil {
+		return token.Error()
+	}
+
+	return nil
+}
+
+func Connect(server, id string) (Client, error) {
+	c := New(server, id)
+	err := c.connect()
+	if err != nil {
+		return Client{}, err
+	}
+
+	return c, nil
+}
+
+func (c Client) PublishMessage(path, message string) error {
+	token := c.mqttClient.Publish(path, 1, false, message)
+	token.Wait()
+	if token.Error() != nil {
+		return token.Error()
+	}
+
+	return nil
+}


### PR DESCRIPTION
## MQTT Client Package (WIP)

`mqttclient` package provides an easy to use interface to publish messages from an arduino-nano33-iot to an MQTT broker.

Look at the file `cmd/arduino-nano33-iot-wifi-mqttclient/main.go` for reference

```go
        mqttc, err := mqttclient.Connect(mqttserver, clientid)
	if err != nil {
		println("error connecting to mqtt: " + err.Error())
	}

	println("connected to MQTT server: " + mqttserver)

	// testing sending messages to MQTT
	println("publishing messages to server: " + mqttserver)

	for {
		rand.Seed(time.Now().Unix())
		temp := rand.Intn(35)
		err = mqttc.PublishMessage("iot/temperature", fmt.Sprintf(`{value: %v}`, temp))
		if err != nil {
			println("error sending message to mqtt")
		}

		time.Sleep(5 * time.Second)
	}
```

![image](https://user-images.githubusercontent.com/74988/184978227-37a487be-2036-4a9a-93aa-df689a0a9a4c.png)
